### PR TITLE
Add support for cocoapods

### DIFF
--- a/react-native-get-random-values.podspec
+++ b/react-native-get-random-values.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-get-random-values"
+  s.version      = "1.1.0"
+  s.summary      = "A small implementation of `getRandomValues` for React Native"
+  s.homepage     = "https://github.com/LinusU/react-native-get-random-values"
+  s.license      = "MIT"
+  s.author       = { "Linus Unnebäck" => "linus@folkdatorn.se" }
+  s.source       = { :git => "https://github.com/LinusU/react-native-get-random-values.git", :tag => "v#{s.version}" }
+  s.source_files = "ios/RNGetRandomValues.{h,m}"
+  s.platform     = :ios, '8.0'
+  s.dependency 'React'
+end


### PR DESCRIPTION
This PR adds a `.podspec` file to this repo to better support react native projects that use cocoapods to manage iOS dependencies.

After adding this library to my project, I was unable to build my iOS app until I added the path to the react headers directory here:
https://github.com/LinusU/react-native-get-random-values/blob/0896cd5a313511ed6750fd59ed3e94c41a06d4bc/ios/RNGetRandomValues.xcodeproj/project.pbxproj#L206-L211

This isn't a great solution, since that file lives in my `node_modules` folder, which isn't checked into source control.

Adding cocoapods support makes the process of adding this library to my project simple again:
```
yarn add react-native-get-random-values
$(npm bin)/react-native link react-native-get-random-values
cd ios/
pod install
```
After doing that, I was able to build my app with no further changes any build configs.

Thanks for making this package!