### PR TITLE
Replace obsolete gradle compile with implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Fix warning `Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.`