### PR TITLE
Use Math.random when debugger is attached

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ function getRandomValues (array) {
   // "Calling synchronous methods on native modules is not supported in Chrome".
   // So in that specific case we fall back to just using Math.random.
   if (__DEV__) {
-    return insecureRandomValues(array)
+    if (typeof global.nativeCallSyncHook === 'undefined') {
+      return insecureRandomValues(array)
+    }
   }
 
   base64Decode(RNGetRandomValues.getRandomBase64(array.byteLength), new Uint8Array(array.buffer, array.byteOffset, array.byteLength))

--- a/index.js
+++ b/index.js
@@ -4,6 +4,21 @@ const base64Decode = require('fast-base64-decode')
 class TypeMismatchError extends Error {}
 class QuotaExceededError extends Error {}
 
+let warned = false
+function insecureRandomValues (array) {
+  if (!warned) {
+    console.warn('Using an insecure random number generator, this should only happen when running with a debugger without support for crypto.getRandomValues')
+    warned = true
+  }
+
+  for (let i = 0, r; i < array.length; i++) {
+    if ((i & 0x03) === 0) r = Math.random() * 0x100000000
+    array[i] = (r >>> ((i & 0x03) << 3)) & 0xff
+  }
+
+  return array
+}
+
 /**
  * @param {Int8Array|Uint8Array|Int16Array|Uint16Array|Int32Array|Uint32Array|Uint8ClampedArray} array
  */
@@ -15,17 +30,12 @@ function getRandomValues (array) {
   if (array.byteLength > 65536) {
     throw new QuotaExceededError('Can only request a maximum of 65536 bytes')
   }
-  
+
   // Calling RNGetRandomValues.getRandomBase64 in debug mode leads to the error
   // "Calling synchronous methods on native modules is not supported in Chrome".
   // So in that specific case we fall back to just using Math.random.
   if (__DEV__) {
-    for (var i = 0, r; i < array.length; i++) {
-      if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
-      array[i] = (r >>> ((i & 0x03) << 3)) & 0xff;
-    }
-
-    return array;
+    return insecureRandomValues(array)
   }
 
   base64Decode(RNGetRandomValues.getRandomBase64(array.byteLength), new Uint8Array(array.buffer, array.byteOffset, array.byteLength))

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ class QuotaExceededError extends Error {}
 let warned = false
 function insecureRandomValues (array) {
   if (!warned) {
-    console.warn('Using an insecure random number generator, this should only happen when running with a debugger without support for crypto.getRandomValues')
+    console.warn('Using an insecure random number generator, this should only happen when running in a debugger without support for crypto.getRandomValues')
     warned = true
   }
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,18 @@ function getRandomValues (array) {
   if (array.byteLength > 65536) {
     throw new QuotaExceededError('Can only request a maximum of 65536 bytes')
   }
+  
+  // Calling RNGetRandomValues.getRandomBase64 in debug mode leads to the error
+  // "Calling synchronous methods on native modules is not supported in Chrome".
+  // So in that specific case we fall back to just using Math.random.
+  if (__DEV__) {
+    for (var i = 0, r; i < array.length; i++) {
+      if ((i & 0x03) === 0) r = Math.random() * 0x100000000;
+      array[i] = (r >>> ((i & 0x03) << 3)) & 0xff;
+    }
+
+    return array;
+  }
 
   base64Decode(RNGetRandomValues.getRandomBase64(array.byteLength), new Uint8Array(array.buffer, array.byteOffset, array.byteLength))
 


### PR DESCRIPTION
Normally this calls a synchronous native method, which is more secure and of course the point of this library, but calling synchronous native methods is not supported when the debugger is attached.

AFAIK this only affects VSCode. Debugging with Chrome or React Native Debugger bypasses this library altogether, in favor of their `global.crypto.getRandomValues`. VSCode does not provide `global.crypto`.

The `Math.random` logic here is directly copied from previous versions of https://github.com/uuidjs/uuid, before they removed it (and encouraged the use of this library).