### PR TITLE
🌊 Add Expo managed workflow support for SDK 39+

### DIFF
--- a/getRandomBase64.expo.js
+++ b/getRandomBase64.expo.js
@@ -1,0 +1,8 @@
+const { NativeModules } = require('react-native')
+
+// In the Expo managed workflow the getRandomBase64 method is provided by ExpoRandom.getRandomBase64String
+if (!NativeModules.ExpoRandom) {
+  throw new Error('Expo managed workflow support for react-native-get-random-values is only available in SDK 39 and higher.')
+}
+
+module.exports = NativeModules.ExpoRandom.getRandomBase64String

--- a/getRandomBase64.js
+++ b/getRandomBase64.js
@@ -1,0 +1,1 @@
+module.exports = require('react-native').NativeModules.RNGetRandomValues.getRandomBase64

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const RNGetRandomValues = require('react-native').NativeModules.RNGetRandomValues
 const base64Decode = require('fast-base64-decode')
+const getRandomBase64 = require('./getRandomBase64')
 
 class TypeMismatchError extends Error {}
 class QuotaExceededError extends Error {}
@@ -31,7 +31,7 @@ function getRandomValues (array) {
     throw new QuotaExceededError('Can only request a maximum of 65536 bytes')
   }
 
-  // Calling RNGetRandomValues.getRandomBase64 in debug mode leads to the error
+  // Calling getRandomBase64 in debug mode leads to the error
   // "Calling synchronous methods on native modules is not supported in Chrome".
   // So in that specific case we fall back to just using Math.random.
   if (__DEV__) {
@@ -40,7 +40,7 @@ function getRandomValues (array) {
     }
   }
 
-  base64Decode(RNGetRandomValues.getRandomBase64(array.byteLength), new Uint8Array(array.buffer, array.byteOffset, array.byteLength))
+  base64Decode(getRandomBase64(array.byteLength), new Uint8Array(array.buffer, array.byteOffset, array.byteLength))
 
   return array
 }

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,15 @@
-# `getRandomValues` for React Native
+# `crypto.getRandomValues` for React Native
 
-A small implementation of `getRandomValues` for React Native.
+A small implementation of `crypto.getRandomValues` for React Native. This is useful to polyfill for libraries like [uuid](https://www.npmjs.com/package/uuid) that depend on it.
 
 ## Installation
 
 ```sh
 npm install --save react-native-get-random-values
-cd ios && pod install && cd ..
+npx pod-install
 ```
+
+> 💡 If you use the Expo managed workflow you will see "CocoaPods is not supported in this project" - this is fine, it's not necessary.
 
 ## Usage
 
@@ -16,6 +18,14 @@ This library works as a polyfill for the global `crypto.getRandomValues`.
 ```javascript
 // Add this line to your `index.js`
 import 'react-native-get-random-values'
+```
+
+Now you can use `uuid` or other libraries that assume `crypto.getRandomValues` is available.
+
+```javascript
+import { v4 as uuid } from 'uuid'
+
+console.log(uuid())
 ```
 
 ## API


### PR DESCRIPTION
This is done by using the ExpoRandom native module when running in the Expo managed workflow, if it exists.

This does not add any overhead to apps that are not running in the Expo managed workflow. The `.expo.js` file is not included in the bundle.

Fixes https://github.com/expo/expo/issues/7209