### PR TITLE
Add support for macOS

### DIFF
--- a/react-native-get-random-values.podspec
+++ b/react-native-get-random-values.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/LinusU/react-native-get-random-values"
   s.license      = "MIT"
   s.authors      = { "Linus Unnebäck" => "linus@folkdatorn.se" }
-  s.platforms    = { :ios => "9.0", :tvos => "9.0" }
+  s.platforms    = { :ios => "9.0", :tvos => "9.0", :osx => "10.14" }
   s.source       = { :git => "https://github.com/LinusU/react-native-get-random-values.git", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION
needed support for react-native-macos, since the code is simple and has no platform specific dependencies simply adding it seems to make it work... but only with the debugger connected (which makes me think it will only work on a production build, which I cannot test right now) seems related to: https://github.com/uuidjs/uuid/issues/416