### PR TITLE
Add peerDependenciesMeta to quiet peer warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "peerDependencies": {
     "react-native": ">=0.56"
   },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    }
+  },
   "keywords": [
     "Crypto.getRandomValues",
     "crypto",


### PR DESCRIPTION
Hello,

I've added a [peerDependenciesMeta](https://yarnpkg.com/configuration/manifest#peerDependenciesMeta) field to package.json which marks the peer dependency on React Native as optional.

This quiets warnings about a missing peer dependency when used on non-React Native projects. One example of where this is desirable is when making use of the `@aws-sdk/middleware-retry` package on non-React Native projects.

The peer dependency range is still validated when a user installs React Native.