### PR TITLE
❌ Get rid of .expo.js extension, no longer supported in Expo SDK 41+

### DIFF
--- a/getRandomBase64.expo.js
+++ b/getRandomBase64.expo.js
@@ -1,8 +1,0 @@
-const { NativeModules } = require('react-native')
-
-// In the Expo managed workflow the getRandomBase64 method is provided by ExpoRandom.getRandomBase64String
-if (!NativeModules.ExpoRandom) {
-  throw new Error('Expo managed workflow support for react-native-get-random-values is only available in SDK 39 and higher.')
-}
-
-module.exports = NativeModules.ExpoRandom.getRandomBase64String

--- a/getRandomBase64.js
+++ b/getRandomBase64.js
@@ -1,1 +1,7 @@
-module.exports = require('react-native').NativeModules.RNGetRandomValues.getRandomBase64
+const { NativeModules } = require('react-native')
+
+if (NativeModules.RNGetRandomValues) {
+  module.exports = NativeModules.RNGetRandomValues.getRandomBase64;
+} else if (NativeModules.ExpoRandom) {
+  module.exports = NativeModules.ExpoRandom.getRandomBase64String
+}

--- a/getRandomBase64.js
+++ b/getRandomBase64.js
@@ -1,7 +1,0 @@
-const { NativeModules } = require('react-native')
-
-if (NativeModules.RNGetRandomValues) {
-  module.exports = NativeModules.RNGetRandomValues.getRandomBase64;
-} else if (NativeModules.ExpoRandom) {
-  module.exports = NativeModules.ExpoRandom.getRandomBase64String
-}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const base64Decode = require('fast-base64-decode')
-const getRandomBase64 = require('./getRandomBase64')
+const { NativeModules } = require('react-native')
 
 class TypeMismatchError extends Error {}
 class QuotaExceededError extends Error {}
@@ -17,6 +17,20 @@ function insecureRandomValues (array) {
   }
 
   return array
+}
+
+/**
+ * @param {number} byteLength
+ * @returns {string}
+ */
+function getRandomBase64 (byteLength) {
+  if (NativeModules.RNGetRandomValues) {
+    return NativeModules.RNGetRandomValues.getRandomBase64(byteLength)
+  } else if (NativeModules.ExpoRandom) {
+    return NativeModules.ExpoRandom.getRandomBase64String(byteLength)
+  } else {
+    throw new Error('Native module not found')
+  }
 }
 
 /**


### PR DESCRIPTION
In SDK 41 we are removing the .expo.js extension! We have sent PRs to other repos like [async-storage](https://github.com/react-native-async-storage/async-storage/pull/544) and [react-native-screens](https://github.com/software-mansion/react-native-screens/pull/823) to resolve this, but I only just remembered that we're depending on it here as well. And so this PR was born.

The changes here are backwards compatible, so it doesn't hurt if someone on Expo SDK 39 or 40 installs a version of the library that includes this code. However, when using SDK 41, people will need to use the latest version. To ensure that, I'll add the library to [the list of libraries that we automatically update](https://github.com/expo/expo/blob/87a3673f56cf291c66eebd518801a70115add9be/packages/expo/bundledNativeModules.json) when running `expo upgrade`.