### PR TITLE
🎉 Add support for Expo SDK 45+

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,11 @@ function getRandomBase64 (byteLength) {
   if (NativeModules.RNGetRandomValues) {
     return NativeModules.RNGetRandomValues.getRandomBase64(byteLength)
   } else if (NativeModules.ExpoRandom) {
+    // Expo SDK 41-44
     return NativeModules.ExpoRandom.getRandomBase64String(byteLength)
+  } else if (global.ExpoModules) {
+    // Expo SDK 45+
+    return global.ExpoModules.ExpoRandom.getRandomBase64String(byteLength);
   } else {
     throw new Error('Native module not found')
   }


### PR DESCRIPTION
In Expo SDK45, `expo-random` is no longer a standard React Native module on iOS. Now it's an Expo JSI module which is exported as `global.ExpoModules.ExpoRandom` instead of `NativeModules.ExpoRandom`.
On Android the old approach still works in SDK45, but will stop working in SDK46.

Fixes https://github.com/expo/expo/issues/17270