### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-get-random-values.podspec
+++ b/react-native-get-random-values.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/LinusU/react-native-get-random-values"
   s.license      = "MIT"
   s.authors      = { "Linus Unnebäck" => "linus@folkdatorn.se" }
-  s.platforms    = { :ios => "9.0", :tvos => "9.0", :osx => "10.14" }
+  s.platforms    = { :ios => "9.0", :tvos => "9.0", :osx => "10.14", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/LinusU/react-native-get-random-values.git", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION
This PR adds support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

The only change needed is adding `:visionos => "1.0"` to the podspec platforms, since all APIs used here are already supported by visionOS :)

![image](https://github.com/LinusU/react-native-get-random-values/assets/26878038/8d90192a-5f97-40bc-87a0-e3491e9f983b)
